### PR TITLE
add merlin and merlin_extend to opam dependencies

### DIFF
--- a/opam
+++ b/opam
@@ -26,6 +26,8 @@ depends: [
   "utop"         {>= "1.17"}
   "BetterErrors" {>= "0.0.1"}
   "menhir"       {>= "20160303"}
+  "merlin"
+  "merlin_extend"
 ]
 depopts: [
 ]


### PR DESCRIPTION
This enables the following workflow to install all infer dependencies:

```sh
opam pin add --yes --no-action merlin 'https://github.com/the-lambda-church/merlin.git#reason-0.0.1' 87ea0e79
opam pin add --yes --no-action merlin_extend 'https://github.com/let-def/merlin-extend.git#reason-0.0.1' ef634252
opam pin add --yes --no-action reason 'https://github.com/jvillard/reason-1.git#master' bba3bd87
opam pin add --yes --no-action infer /path/to/infer
opam install --yes --deps-only infer
```

Without this change, this would fail as opam can decide to install reason before merlin or merlin_extend. Installing merlin/merlin_extend manually before the rest of the dependencies somehow results in different versions of certain packages to be installed, which have to be reinstalled at the correct version in the last step (plus it wastes some parallelism).